### PR TITLE
docs: adds a linebreak in examples.md.

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -31,6 +31,7 @@ ExecStart=/usr/bin/echo Hello World
 [Install]
 WantedBy=multi-user.target
 ```
+
 ### Modifying Services
 
 This config will add a [systemd unit drop-in](https://coreos.com/os/docs/latest/using-systemd-drop-in-units.html) to modify the existing service `systemd-networkd` and sets its environment variable `SYSTEMD_LOG_LEVEL` to `debug`.


### PR DESCRIPTION
I think this will fix a formatting issue on coreos.com.